### PR TITLE
feat: Add http request options

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,8 +8,15 @@ jobs:
     strategy:
       max-parallel: 15
       matrix:
-        laravel-version: ['^6.0', '^7.0', '^8.0']
-        php-versions: ['7.3', '7.4', '8.0']
+        laravel-version: ['^6.0', '^7.0', '^8.0', '^9.0']
+        php-versions: ['7.4', '8.0']
+        exclude:
+          - laravel-version: ^6.0
+            php-versions: 8.0
+          - laravel-version: ^7.0
+            php-versions: 8.0
+          - laravel-version: ^9.0
+            php-versions: 7.4
     name: PHP ${{ matrix.php-versions }} on Laravel ${{ matrix.laravel-version }}
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "guzzlehttp/guzzle": "^6.2 || ^7.0",
-        "illuminate/notifications": "^6.0 || ^7.0 || ^8.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0"
+        "illuminate/notifications": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^9.0",
-        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0"
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -38,12 +38,16 @@ class WebhookChannel
 
         $webhookData = $notification->toWebhook($notifiable)->toArray();
 
-        $response = $this->client->post($url, [
-            'query' => Arr::get($webhookData, 'query'),
-            'body' => json_encode(Arr::get($webhookData, 'data')),
-            'verify' => Arr::get($webhookData, 'verify'),
-            'headers' => Arr::get($webhookData, 'headers'),
-        ]);
+        $response = $this->client->post($url, array_merge(
+            [
+                'query' => Arr::get($webhookData, 'query'),
+                'body' => json_encode(Arr::get($webhookData, 'data')),
+                'verify' => Arr::get($webhookData, 'verify'),
+                'headers' => Arr::get($webhookData, 'headers'),
+            ],
+            Arr::get($webhookData, 'http')
+        ));
+
 
         if ($response->getStatusCode() >= 300 || $response->getStatusCode() < 200) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -32,7 +32,7 @@ class WebhookChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (!$url = $notifiable->routeNotificationFor('webhook')) {
+        if (! $url = $notifiable->routeNotificationFor('webhook')) {
             return;
         }
 

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -32,7 +32,7 @@ class WebhookChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $url = $notifiable->routeNotificationFor('webhook')) {
+        if (!$url = $notifiable->routeNotificationFor('webhook')) {
             return;
         }
 

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -40,6 +40,13 @@ class WebhookMessage
     protected $verify = false;
 
     /**
+     * Additional request options for the Guzzle HTTP client.
+     *
+     * @var array
+     */
+    protected $http = [];
+
+    /**
      * @param mixed $data
      *
      * @return static
@@ -126,6 +133,20 @@ class WebhookMessage
         return $this;
     }
 
+
+    /**
+     * Set additional request options for the Guzzle HTTP client.
+     *
+     * @param  array  $options
+     * @return $this
+     */
+    public function http(array $options)
+    {
+        $this->http = $options;
+
+        return $this;
+    }
+
     /**
      * @return array
      */
@@ -136,6 +157,7 @@ class WebhookMessage
             'data' => $this->data,
             'headers' => $this->headers,
             'verify' => $this->verify,
+            'http' => $this->http,
         ];
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -67,4 +67,11 @@ class MessageTest extends TestCase
         $this->message->verify();
         $this->assertEquals(true, Arr::get($this->message->toArray(), 'verify'));
     }
+
+    /** @test */
+    public function it_can_add_request_options()
+    {
+        $this->message->http(['timeout' => 3.14]);
+        $this->assertEquals(3.14, Arr::get($this->message->toArray(), 'http.timeout'));
+    }
 }


### PR DESCRIPTION
Added `http()` to allow setting HTTP options such as timeout value as requested in #46.